### PR TITLE
 [Breaking] Fix the working directory for the middlewares service

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,9 @@ const express = require('express');
 // Create the app
 const app = express();
 
-// Tell the plugin to configure the necessary middlewares for the `myApp` target on the app
-useExpress(app, 'myApp');
+// Tell the plugin to configure the necessary middlewares for the `myApp` target to be served by the
+// `myServer` target
+useExpress(app, 'myApp', 'myServer');
 
 // Start the app
 app.listen(...);
@@ -85,8 +86,9 @@ class DevApp extends Jimpex {}
 // Create the app
 const app = new DevApp();
 
-// Tell the plugin to configure the necessary middlewares for the `myApp` target on the app
-useJimpex(app, 'myApp');
+// Tell the plugin to configure the necessary middlewares for the `myApp` target to be served by the
+// `myServer` target
+useJimpex(app, 'myApp', 'myServer');
 
 // Start the app
 app.start();
@@ -97,7 +99,7 @@ app.start();
 Both `useExpress` and `useJimpex` return and object with the following properties:
 
 - `middlewares`: A list with the implemented middlewares.
-- `getDirectory`: A function that returns the directory from where the dev middleware is serving the files.
+- `getDirectory`: A function that returns the build directory of the target implementing the middleware(s).
 - `getFileSystem`: A function that returns a promise with the instance of the _"virtual file system"_ the middleware uses to read and write the files in memory.
 
 ### Extending/Overwriting the configuration

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
       "jest-ex": "4.0.0",
       "jest-cli": "22.1.4",
       "jasmine-expect": "3.8.3",
-      "jimpex": "^1.0.3",
+      "jimpex": "^2.0.0",
       "esdoc": "1.0.4",
       "esdoc-standard-plugin": "1.0.0",
       "esdoc-node": "1.0.3",

--- a/src/express.js
+++ b/src/express.js
@@ -1,15 +1,24 @@
 const woopack = require('woopack/index');
 /**
  * Implements the Webpack middlewares for a target on an Express app.
- * @param {Express} expressApp The app where the middlewares are going to be `use`d.
- * @param {string}  targetName The name of the target for which the middlewares are for.
+ * @param {Express} expressApp    The app where the middlewares are going to be `use`d.
+ * @param {string}  targetToBuild The name of the target that will be builded on the middleware(s).
+ * @param {string}  targetToServe The name of the target that will implement the middleware(s). When
+ *                                the other target is builded, it will assume that is on the
+ *                                distribution directory, and if the target serving it is being
+ *                                executed from the source directory it won't be able to use the
+ *                                dev middleware file system without hardcoding some relatives paths
+ *                                from the build to the source; to avoid that, the method gets
+ *                                the build path of this target, so when using `getDirectory()`, it
+ *                                will think they are both on the distribution directory and the
+ *                                paths can be created relative to that.
  * @return {MiddlewaresInformation}
  */
-const useExpress = (expressApp, targetName) => {
+const useExpress = (expressApp, targetToBuild, targetToServe) => {
   // Get the middlewares service.
   const webpackMiddlewares = woopack.get('webpackMiddlewares');
   // Generate the middlewares for the target.
-  const info = webpackMiddlewares.generate(targetName);
+  const info = webpackMiddlewares.generate(targetToBuild, targetToServe);
   // Loop all the received middlewares...
   info.middlewares.forEach((middleware) => {
     // ...and register them on the app.

--- a/src/jimpex.js
+++ b/src/jimpex.js
@@ -4,15 +4,24 @@ const { middleware } = require('jimpex');
 const { webpackFrontendFs, webpackSendFile } = require('./jimpex/index');
 /**
  * Implements the Webpack middlewares for a target on a Jimpex app.
- * @param {Jimpex}  jimpexApp  The app where the middlewares are going to be registered..
- * @param {string}  targetName The name of the target for which the middlewares are for.
+ * @param {Jimpex} jimpexApp     The app where the middlewares are going to be registered.
+ * @param {string} targetToBuild The name of the target that will be builded on the middleware(s).
+ * @param {string} targetToServe The name of the target that will implement the middleware(s). When
+ *                               the other target is builded, it will assume that is on the
+ *                               distribution directory, and if the target serving it is being
+ *                               executed from the source directory it won't be able to use the
+ *                               dev middleware file system without hardcoding some relatives paths
+ *                               from the build to the source; to avoid that, the method gets
+ *                               the build path of this target, so when using `getDirectory()`, it
+ *                               will think they are both on the distribution directory and the
+ *                               paths can be created relative to that.
  * @return {MiddlewaresInformation}
  */
-const useJimpex = (jimpexApp, targetName) => {
+const useJimpex = (jimpexApp, targetToBuild, targetToServe) => {
   // Get the middlewares service.
   const webpackMiddlewares = woopack.get('webpackMiddlewares');
   // Generate the middlewares for the target.
-  const info = webpackMiddlewares.generate(targetName);
+  const info = webpackMiddlewares.generate(targetToBuild, targetToServe);
   /**
    * Register the overwrite services...
    * - The `webpackFrontendFs` overwrites the regular `frontendFs` in order to read files from

--- a/src/services/server/middlewares.js
+++ b/src/services/server/middlewares.js
@@ -80,16 +80,28 @@ class WebpackMiddlewares {
   }
   /**
    * Generate the middlewares for a given target.
-   * @param {string} targetName The name of the target.
+   * @param {string} targetToBuild The name of the target that will be builded on the middleware(s).
+   * @param {string} targetToServe The name of the target that will implement the middleware(s).
+   *                               When the other target is builded, it will assume that is on the
+   *                               distribution directory, and if the target serving it is being
+   *                               executed from the source directory it won't be able to use the
+   *                               dev middleware file system without hardcoding some relatives
+   *                               paths from the build to the source; to avoid that, the method
+   *                               gets the build path of this target, so when using
+   *                               `getDirectory()`, it will think they are both on the
+   *                               distribution directory and the paths can be created relative to
+   *                               that.
    * @return {MiddlewaresInformation}
    */
-  generate(targetName) {
+  generate(targetToBuild, targetToServe) {
     // Get the target information.
-    const target = this.targets.getTarget(targetName);
+    const target = this.targets.getTarget(targetToBuild);
     // Set the flag indicating the dev middleware file system is not ready.
-    this._fileSystemsReady[targetName] = false;
+    this._fileSystemsReady[targetToBuild] = false;
     // Create the deferred promise for when the dev middleware file system is ready.
-    this._fileSystemsDeferreds[targetName] = deferred();
+    this._fileSystemsDeferreds[targetToBuild] = deferred();
+    // Set the target working directory as the target that serves it build folder
+    this._directories[targetToBuild] = this.targets.getTarget(targetToServe).paths.build;
     // Create the list of middlewares with just the dev middleware.
     const middlewares = [
       () => this.devMiddleware(target),
@@ -158,7 +170,8 @@ class WebpackMiddlewares {
    *                                       the target.
    * @property {?middleware} hotMiddleware An instance of the Webpack hot middleware, if needed
    *                                       by the target.
-   * @property {string}      directory     The dev middleware root directory.
+   * @property {string}      directory     The build directory of the target implementing the
+   *                                       middleware.
    * @ignore
    * @access protected
    */
@@ -167,7 +180,6 @@ class WebpackMiddlewares {
       this._compiled.push(target.name);
       const configuration = this.webpackConfiguration.getConfig(target, 'development');
       configuration.plugins.push(this._getFileSystemStatusPlugin(target));
-      this._directories[target.name] = configuration.output.path;
 
       const compiler = webpack(configuration);
       const middlewareOptions = {

--- a/src/typedef.js
+++ b/src/typedef.js
@@ -91,7 +91,7 @@
 /**
  * @typedef {function} DevMiddlewareGetDirectory
  * @return {string}
- * The directory from where the webpack dev middleware is serving the files.
+ * The build directory of the target implementing the dev middleware.
  */
 
 /**
@@ -106,7 +106,7 @@
  * @property {Array} middlewares
  * A list of functions that when executed return a Node middleware.
  * @property {DevMiddlewareGetDirectory} getDirectory
- * To access the webpack dev middleware working directory.
+ * To access the target implementing the middleware build directory.
  * @property {DevMiddlewareGetFileSystem} getFileSystem
  * To access the webpack dev middleware _"virtual filesystem"_.
  */

--- a/tests/express.test.js
+++ b/tests/express.test.js
@@ -26,16 +26,17 @@ describe('plugin:woopackWebpack/Express', () => {
       generate: jest.fn(() => info),
     };
     woopack.get.mockImplementationOnce(() => webpackMiddlewares);
-    const target = 'target-name';
+    const targetToBuild = 'target-to-build';
+    const targetToServe = 'target-to-serve';
     let result = null;
     // When
-    result = expressImplementation(expressApp, target);
+    result = expressImplementation(expressApp, targetToBuild, targetToServe);
     // Then
     expect(result).toEqual(info);
     expect(woopack.get).toHaveBeenCalledTimes(1);
     expect(woopack.get).toHaveBeenCalledWith('webpackMiddlewares');
     expect(webpackMiddlewares.generate).toHaveBeenCalledTimes(1);
-    expect(webpackMiddlewares.generate).toHaveBeenCalledWith(target);
+    expect(webpackMiddlewares.generate).toHaveBeenCalledWith(targetToBuild, targetToServe);
     expect(expressApp.use).toHaveBeenCalledTimes(info.middlewares.length);
     info.middlewares.forEach(() => {
       expect(expressApp.use).toHaveBeenCalledWith(middlewareCall);

--- a/tests/jimpex.test.js
+++ b/tests/jimpex.test.js
@@ -49,18 +49,19 @@ describe('plugin:woopackWebpack/Jimpex', () => {
     };
     woopack.get.mockImplementationOnce(() => webpackMiddlewares);
     jimpex.middleware.mockImplementation((fn) => fn());
-    const target = 'target-name';
+    const targetToBuild = 'target-to-build';
+    const targetToServe = 'target-to-serve';
     const expectedRegisteredServices = [
       'webpackFrontendFs',
       'webpackSendFile',
     ];
     // When
-    jimpexImplementation(jimpexApp, target);
+    jimpexImplementation(jimpexApp, targetToBuild, targetToServe);
     // Then
     expect(woopack.get).toHaveBeenCalledTimes(1);
     expect(woopack.get).toHaveBeenCalledWith('webpackMiddlewares');
     expect(webpackMiddlewares.generate).toHaveBeenCalledTimes(1);
-    expect(webpackMiddlewares.generate).toHaveBeenCalledWith(target);
+    expect(webpackMiddlewares.generate).toHaveBeenCalledWith(targetToBuild, targetToServe);
     expect(jimpexApp.register).toHaveBeenCalledTimes(expectedRegisteredServices.length);
     expectedRegisteredServices.forEach((service) => {
       expect(jimpexApp.register).toHaveBeenCalledWith(service);
@@ -109,21 +110,22 @@ describe('plugin:woopackWebpack/Jimpex', () => {
     };
     woopack.get.mockImplementationOnce(() => webpackMiddlewares);
     jimpex.middleware.mockImplementation((fn) => fn());
-    const target = 'target-name';
+    const targetToBuild = 'target-to-build';
+    const targetToServe = 'target-to-serve';
     let eventListener = null;
     const expectedRegisteredServices = [
       'webpackFrontendFs',
       'webpackSendFile',
     ];
     // When
-    jimpexImplementation(jimpexApp, target);
+    jimpexImplementation(jimpexApp, targetToBuild, targetToServe);
     [[, eventListener]] = events.once.mock.calls;
     eventListener();
     // Then
     expect(woopack.get).toHaveBeenCalledTimes(1);
     expect(woopack.get).toHaveBeenCalledWith('webpackMiddlewares');
     expect(webpackMiddlewares.generate).toHaveBeenCalledTimes(1);
-    expect(webpackMiddlewares.generate).toHaveBeenCalledWith(target);
+    expect(webpackMiddlewares.generate).toHaveBeenCalledWith(targetToBuild, targetToServe);
     expect(jimpexApp.register).toHaveBeenCalledTimes(expectedRegisteredServices.length);
     expectedRegisteredServices.forEach((service) => {
       expect(jimpexApp.register).toHaveBeenCalledWith(service);

--- a/tests/services/server/middlewares.test.js
+++ b/tests/services/server/middlewares.test.js
@@ -46,27 +46,37 @@ describe('services/server:middlewares', () => {
   it('should generate the middleware information object for a target', () => {
     // Given
     const events = 'events';
-    const targetName = 'some-target';
-    const target = {
-      name: targetName,
+    const targetToBuild = {
+      name: 'target-to-build',
+    };
+    const targetToServe = {
+      name: 'target-to-serve',
+      paths: {
+        build: 'dist/server',
+      },
+    };
+    const targetsList = {
+      [targetToBuild.name]: targetToBuild,
+      [targetToServe.name]: targetToServe,
     };
     const targets = {
-      getTarget: jest.fn(() => target),
+      getTarget: jest.fn((name) => targetsList[name]),
     };
     const webpackConfiguration = 'webpackConfiguration';
     let sut = null;
     let result = null;
     // When
     sut = new WebpackMiddlewares(events, targets, webpackConfiguration);
-    result = sut.generate(targetName);
+    result = sut.generate(targetToBuild.name, targetToServe.name);
     // Then
     expect(result).toEqual({
       getDirectory: expect.any(Function),
       getFileSystem: expect.any(Function),
       middlewares: expect.any(Array),
     });
-    expect(targets.getTarget).toHaveBeenCalledTimes(1);
-    expect(targets.getTarget).toHaveBeenCalledWith(targetName);
+    expect(targets.getTarget).toHaveBeenCalledTimes(2);
+    expect(targets.getTarget).toHaveBeenCalledWith(targetToBuild.name);
+    expect(targets.getTarget).toHaveBeenCalledWith(targetToServe.name);
   });
 
   it('should generate the dev middleware for a target', () => {
@@ -78,12 +88,21 @@ describe('services/server:middlewares', () => {
     const events = {
       reduce: jest.fn((name, options) => options),
     };
-    const targetName = 'some-target';
-    const target = {
-      name: targetName,
+    const targetToBuild = {
+      name: 'target-to-build',
+    };
+    const targetToServe = {
+      name: 'target-to-serve',
+      paths: {
+        build: 'dist/server',
+      },
+    };
+    const targetsList = {
+      [targetToBuild.name]: targetToBuild,
+      [targetToServe.name]: targetToServe,
     };
     const targets = {
-      getTarget: jest.fn(() => target),
+      getTarget: jest.fn((name) => targetsList[name]),
     };
     const webpackConfig = {
       output: {
@@ -100,7 +119,7 @@ describe('services/server:middlewares', () => {
     let middlewareResult = null;
     // When
     sut = new WebpackMiddlewares(events, targets, webpackConfiguration);
-    result = sut.generate(targetName);
+    result = sut.generate(targetToBuild.name, targetToServe.name);
     [middleware] = result.middlewares;
     middlewareResult = middleware();
     // Then
@@ -112,8 +131,9 @@ describe('services/server:middlewares', () => {
     expect(result.middlewares.length).toBe(1);
     expect(middleware).toBeFunction();
     expect(middlewareResult).toBe(devMiddleware);
-    expect(targets.getTarget).toHaveBeenCalledTimes(1);
-    expect(targets.getTarget).toHaveBeenCalledWith(targetName);
+    expect(targets.getTarget).toHaveBeenCalledTimes(2);
+    expect(targets.getTarget).toHaveBeenCalledWith(targetToBuild.name);
+    expect(targets.getTarget).toHaveBeenCalledWith(targetToServe.name);
     expect(webpack).toHaveBeenCalledTimes(1);
     expect(webpack).toHaveBeenCalledWith(Object.assign({}, webpackConfig, {
       plugins: [{
@@ -127,7 +147,7 @@ describe('services/server:middlewares', () => {
         publicPath: webpackConfig.output.publicPath,
         stats: expect.any(Object),
       },
-      target
+      targetToBuild
     );
     expect(webpackRealDevMiddleware).toHaveBeenCalledTimes(1);
     expect(webpackRealDevMiddleware).toHaveBeenCalledWith(
@@ -150,13 +170,22 @@ describe('services/server:middlewares', () => {
     const events = {
       reduce: jest.fn((name, options) => options),
     };
-    const targetName = 'some-target';
-    const target = {
-      name: targetName,
+    const targetToBuild = {
+      name: 'target-to-build',
       hot: true,
     };
+    const targetToServe = {
+      name: 'target-to-serve',
+      paths: {
+        build: 'dist/server',
+      },
+    };
+    const targetsList = {
+      [targetToBuild.name]: targetToBuild,
+      [targetToServe.name]: targetToServe,
+    };
     const targets = {
-      getTarget: jest.fn(() => target),
+      getTarget: jest.fn((name) => targetsList[name]),
     };
     const webpackConfig = {
       output: {
@@ -175,7 +204,7 @@ describe('services/server:middlewares', () => {
     let middlewareHotResult = null;
     // When
     sut = new WebpackMiddlewares(events, targets, webpackConfiguration);
-    result = sut.generate(targetName);
+    result = sut.generate(targetToBuild.name, targetToServe.name);
     [middleware, middlewareHot] = result.middlewares;
     middlewareResult = middleware();
     middlewareHotResult = middlewareHot();
@@ -190,8 +219,9 @@ describe('services/server:middlewares', () => {
     expect(middlewareResult).toBe(devMiddleware);
     expect(middlewareHot).toBeFunction();
     expect(middlewareHotResult).toBe(hotMiddleware);
-    expect(targets.getTarget).toHaveBeenCalledTimes(1);
-    expect(targets.getTarget).toHaveBeenCalledWith(targetName);
+    expect(targets.getTarget).toHaveBeenCalledTimes(2);
+    expect(targets.getTarget).toHaveBeenCalledWith(targetToBuild.name);
+    expect(targets.getTarget).toHaveBeenCalledWith(targetToServe.name);
     expect(webpack).toHaveBeenCalledTimes(1);
     expect(webpack).toHaveBeenCalledWith(Object.assign({}, webpackConfig, {
       plugins: [{
@@ -205,7 +235,7 @@ describe('services/server:middlewares', () => {
         publicPath: webpackConfig.output.publicPath,
         stats: expect.any(Object),
       },
-      target
+      targetToBuild
     );
     expect(webpackRealDevMiddleware).toHaveBeenCalledTimes(1);
     expect(webpackRealDevMiddleware).toHaveBeenCalledWith(
@@ -230,12 +260,21 @@ describe('services/server:middlewares', () => {
     const events = {
       reduce: jest.fn((name, options) => options),
     };
-    const targetName = 'some-target';
-    const target = {
-      name: targetName,
+    const targetToBuild = {
+      name: 'target-to-build',
+    };
+    const targetToServe = {
+      name: 'target-to-serve',
+      paths: {
+        build: 'dist/server',
+      },
+    };
+    const targetsList = {
+      [targetToBuild.name]: targetToBuild,
+      [targetToServe.name]: targetToServe,
     };
     const targets = {
-      getTarget: jest.fn(() => target),
+      getTarget: jest.fn((name) => targetsList[name]),
     };
     const webpackConfig = {
       output: {
@@ -258,7 +297,7 @@ describe('services/server:middlewares', () => {
     let middlewareResult = null;
     // When
     sut = new WebpackMiddlewares(events, targets, webpackConfiguration);
-    result = sut.generate(targetName);
+    result = sut.generate(targetToBuild.name, targetToServe.name);
     getFileSystemFn = result.getFileSystem;
     [middleware] = result.middlewares;
     middlewareResult = middleware();
@@ -284,7 +323,7 @@ describe('services/server:middlewares', () => {
     });
   });
 
-  it('should give access to the dev middleware working directory', () => {
+  it('should give access to the target using the middleware build directory', () => {
     // Given
     const compiled = 'compiled';
     webpack.mockImplementationOnce(() => compiled);
@@ -295,12 +334,21 @@ describe('services/server:middlewares', () => {
     const events = {
       reduce: jest.fn((name, options) => options),
     };
-    const targetName = 'some-target';
-    const target = {
-      name: targetName,
+    const targetToBuild = {
+      name: 'target-to-build',
+    };
+    const targetToServe = {
+      name: 'target-to-serve',
+      paths: {
+        build: 'dist/server',
+      },
+    };
+    const targetsList = {
+      [targetToBuild.name]: targetToBuild,
+      [targetToServe.name]: targetToServe,
     };
     const targets = {
-      getTarget: jest.fn(() => target),
+      getTarget: jest.fn((name) => targetsList[name]),
     };
     const webpackConfig = {
       output: {
@@ -317,12 +365,12 @@ describe('services/server:middlewares', () => {
     let middleware = null;
     // When
     sut = new WebpackMiddlewares(events, targets, webpackConfiguration);
-    result = sut.generate(targetName);
+    result = sut.generate(targetToBuild.name, targetToServe.name);
     [middleware] = result.middlewares;
     middleware();
     directoryResult = result.getDirectory();
     // Then
-    expect(directoryResult).toBe(webpackConfig.output.path);
+    expect(directoryResult).toBe(targetToServe.paths.build);
   });
 
   it('should include a provider for the DIC', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4913,9 +4913,9 @@ jest-worker@^22.1.0:
   dependencies:
     merge-stream "^1.0.1"
 
-jimpex@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/jimpex/-/jimpex-1.0.3.tgz#7a7fcbbe8756960a1f68244d7119b30734e572cf"
+jimpex@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/jimpex/-/jimpex-2.0.0.tgz#f746cabcda3c41e5e8312895b759e4e58ad57e4d"
   dependencies:
     body-parser "1.18.2"
     compression "1.7.1"


### PR DESCRIPTION
### What does this PR do?

#### The problem

The working directory the middlewares implementation were returning (using `getDirectory()`) was the distribution directory path of the target being built, and if the target implementing the middleware(s) needed to access a generated file, it would had to know from where it was being executed: distribution directory if bundled or transpiled, or source directory.

This would've forced you to hard code some relative paths, with conditionals depending on where is was being executed from.

#### The solution

Now, the service that generate the middleware(s), requires a second parameter for generating middlewares: The name of the target that will implement them.

By doing that, when you call the `getDirectory()` method of the object the service returns, you won't get the working directory of the dev middleware, but the build path of the target implementing it, so the relative paths yo had can now be relative to the same distribution directory.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```
