### PR TITLE
Fixes the implementation of HMR

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "author": "Leonardo Apiwan (@homer0) <me@homer0.com>",
     "license": "MIT",
     "dependencies": {
-      "woopack": "^1.0.0",
-      "wootils": "^1.0.5",
+      "woopack": "^1.0.1",
+      "wootils": "^1.1.1",
       "jimple": "homer0/jimple",
       "fs-extra": "5.0.0",
       "extend": "3.0.1",

--- a/tests/mocks/webpack.mock.js
+++ b/tests/mocks/webpack.mock.js
@@ -2,6 +2,7 @@ const mocks = {
   noEmitOnErrorsPlugin: jest.fn(),
   definePlugin: jest.fn(),
   hotModuleReplacementPlugin: jest.fn(),
+  namedModulesPlugin: jest.fn(),
 };
 
 class NoEmitOnErrorsPluginMock {
@@ -25,6 +26,13 @@ class HotModuleReplacementPluginMock {
   }
 }
 
+class NamedModulesPluginMock {
+  constructor(...args) {
+    this.constructorMock = mocks.namedModulesPlugin;
+    this.constructorMock(...args);
+  }
+}
+
 class WebpackMock {
   static mock(name, mock) {
     mocks[name] = mock;
@@ -44,3 +52,5 @@ module.exports.DefinePlugin = DefinePluginMock;
 module.exports.DefinePluginMock = mocks.definePlugin;
 module.exports.HotModuleReplacementPlugin = HotModuleReplacementPluginMock;
 module.exports.HotModuleReplacementPluginMock = mocks.hotModuleReplacementPlugin;
+module.exports.NamedModulesPlugin = NamedModulesPluginMock;
+module.exports.NamedModulesPluginMock = mocks.namedModulesPlugin;

--- a/yarn.lock
+++ b/yarn.lock
@@ -9040,9 +9040,9 @@ window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
 
-woopack@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/woopack/-/woopack-1.0.0.tgz#125f580725af218b2fc4ac106002523ed4644c45"
+woopack@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/woopack/-/woopack-1.0.1.tgz#ccb78728447de645bf29d524b7b564374f4c1b70"
   dependencies:
     babel-cli "6.26.0"
     babel-core "6.26.0"
@@ -9067,6 +9067,16 @@ woopack@^1.0.0:
 wootils@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/wootils/-/wootils-1.0.5.tgz#8e7c35b8d2167e93c967c6a3c6522712579172e7"
+  dependencies:
+    colors "1.1.2"
+    fs-extra "5.0.0"
+    jimple homer0/jimple
+    statuses "1.4.0"
+    urijs "1.19.0"
+
+wootils@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/wootils/-/wootils-1.1.1.tgz#159e2bdd0f6249b07dce08f8ffc029874b631ca6"
   dependencies:
     colors "1.1.2"
     fs-extra "5.0.0"


### PR DESCRIPTION
### What does this PR do?

These changes apply when the target `hot` setting is `true`:

- It adds the [NamedModulesPlugin](https://webpack.js.org/plugins/named-modules-plugin/) plugin.
- Instead of configuring only the `webpack-hot-middleware`, it now checks if the target will run in order to configure the dev server or the middleware.
- If the target uses the `babel-polyfill`, it now makes sure the HMR entries are added after it and not just on top of the list.

Before this change, it wasn't possible for a target to use HMR on the dev server.

### How should it be tested manually?

```bash
yarn test
# or
npm test
```